### PR TITLE
Fix for two somewhat related issues with category external_id

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -114,7 +114,7 @@ class Data extends AbstractHelper
     
     /**
      * This unique ID can only contain alphanumeric characters (letters and numbers
-     * only) and also the asterisk, hyphen, period, and underscore characters. If your
+     * only) and also the asterisk, hyphen, and underscore characters. If your
      * product IDs contain invalid characters, simply replace them with an alternate
      * character like an underscore. This will only be used in the feed and not for
      * any customer facing purpose.
@@ -131,7 +131,7 @@ class Data extends AbstractHelper
          * Example encoded = qwerty_bv36__bv37__bv64__bv35_asdf
          */
 
-        return preg_replace_callback('/[^\w\d\*-\._]/s', create_function('$match', 'return "_bv".ord($match[0])."_";'), $rawId);
+        return preg_replace_callback('/[^\w\d\*-\-_]/s', create_function('$match', 'return "_bv".ord($match[0])."_";'), $rawId);
     }
 
 

--- a/Model/Feed/Product/Generic.php
+++ b/Model/Feed/Product/Generic.php
@@ -84,6 +84,7 @@ class Generic
             $rawCategoryId = $category->getUrlPath();
 
             $rawCategoryId = str_replace('/', '-', $rawCategoryId);
+            $rawCategoryId = str_replace('.html', '', $rawCategoryId);
             return $this->_helper->replaceIllegalCharacters($rawCategoryId);
         }
     }

--- a/Model/Indexer/Flat.php
+++ b/Model/Indexer/Flat.php
@@ -494,6 +494,7 @@ class Flat implements \Magento\Framework\Indexer\ActionInterface, \Magento\Frame
 
             if ($this->_helper->getConfig('feeds/category_id_use_url_path', $storeId)) {
                 $indexData['category_external_id'] = str_replace('/', '-', $indexData['category_external_id']);
+                $indexData['category_external_id'] = str_replace('.html', '', $indexData['category_external_id']);
                 $indexData['category_external_id'] = $this->_helper->replaceIllegalCharacters($indexData['category_external_id']);
             }
             if ($indexData['category_external_id'] == '') {


### PR DESCRIPTION
First, although ASCII 46 is technically a legal character for the unique id values according to bv XML spec… according to the system integrators, any category external_id with a period in it is not parsed correctly by their feed ingest, regardless of whether the XML is valid. So, kicked the regex in the sanitization helper down to allowing ASCII 42-45 and replacing periods with underscores.
Second, if Magento is set to add ‘.html’ to the end of category paths, it is not applied equally to product collections and category collections… i.e. category collections’ categories’ paths have ‘.html’ added, and product collections’ products’ category paths do not. The end result was that products’ category external_ids and category external_ids didn’t match up. So, added additional str_replace for the ‘.html’ string, which should remove it completely from the path in category nodes, before the sanitization and after the ‘/‘ -> ‘-‘ replace.
The upshot is that category external ids should be the same in product and category nodes, and be parsable by the BV backend.