### PR TITLE
Fixes #7, simplifies InstallData

### DIFF
--- a/Setup/InstallData.php
+++ b/Setup/InstallData.php
@@ -32,10 +32,10 @@ use Magento\Catalog\Model\Product;
 class InstallData implements Setup\InstallDataInterface
 {
     /** @var SalesSetupFactory */
-    protected $_salesSetupFactory;
+    protected $salesSetupFactory;
 
     /** @var CategorySetupFactory */
-    protected $_categorySetupFactory;
+    protected $categorySetupFactory;
 
     /**
      * @param SalesSetupFactory $salesSetupFactory
@@ -45,8 +45,8 @@ class InstallData implements Setup\InstallDataInterface
         SalesSetupFactory $salesSetupFactory,
         CategorySetupFactory $categorySetupFactory
     ) {
-        $this->_salesSetupFactory = $salesSetupFactory;
-        $this->_categorySetupFactory = $categorySetupFactory;
+        $this->salesSetupFactory = $salesSetupFactory;
+        $this->categorySetupFactory = $categorySetupFactory;
     }
 
     /**
@@ -56,7 +56,7 @@ class InstallData implements Setup\InstallDataInterface
     public function install(Setup\ModuleDataSetupInterface $setup, Setup\ModuleContextInterface $context)
     {
         /** @var SalesSetup $eavSetup */
-        $eavSetup = $this->_salesSetupFactory->create(['setup' => $setup]);
+        $eavSetup = $this->salesSetupFactory->create(['setup' => $setup]);
 
         $eavSetup->addAttribute(
             Order::ENTITY,
@@ -70,7 +70,7 @@ class InstallData implements Setup\InstallDataInterface
         );
 
         /** @var CategorySetup $eavSetup */
-        $eavSetup = $this->_categorySetupFactory->create(['setup' => $setup]);
+        $eavSetup = $this->categorySetupFactory->create(['setup' => $setup]);
 
         $eavSetup->addAttribute(
             Product::ENTITY,

--- a/Setup/InstallData.php
+++ b/Setup/InstallData.php
@@ -37,33 +37,17 @@ class InstallData implements Setup\InstallDataInterface
     /** @var CategorySetupFactory */
     protected $_categorySetupFactory;
 
-    /** @var ObjectManagerInterface */
-    protected $_objectManager;
-
-    /** @var  State */
-    protected $_state;
-
     /**
-     * Init
-     *
      * @param SalesSetupFactory $salesSetupFactory
      * @param CategorySetupFactory $categorySetupFactory
-     * @param ObjectManagerInterface $objectManger
-     * @param State $state
      */
     public function __construct(
         SalesSetupFactory $salesSetupFactory,
-        CategorySetupFactory $categorySetupFactory,
-        ObjectManagerInterface $objectManger,
-        State $state
-    )
-    {
+        CategorySetupFactory $categorySetupFactory
+    ) {
         $this->_salesSetupFactory = $salesSetupFactory;
         $this->_categorySetupFactory = $categorySetupFactory;
-        $this->_objectManager = $objectManger;
-        $this->_state = $state;
     }
-
 
     /**
      * {@inheritdoc}
@@ -71,13 +55,6 @@ class InstallData implements Setup\InstallDataInterface
     // @codingStandardsIgnoreStart
     public function install(Setup\ModuleDataSetupInterface $setup, Setup\ModuleContextInterface $context)
     {
-        // @codingStandardsIgnoreEnd
-        try {
-            $this->_state->getAreaCode();
-        } Catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->_state->setAreaCode('frontend');
-        }
-
         /** @var SalesSetup $eavSetup */
         $eavSetup = $this->_salesSetupFactory->create(['setup' => $setup]);
 
@@ -138,23 +115,5 @@ class InstallData implements Setup\InstallDataInterface
         if (!$eavSetup->getAttributesNumberInGroup($entityTypeId, $attributeSetId, 'Product Details')) {
             $eavSetup->removeAttributeGroup($entityTypeId, $attributeSetId, 'Product Details');
         }
-
-        $attrData = array(
-            Connector\Model\Feed\ProductFeed::INCLUDE_IN_FEED_FLAG => \Magento\Catalog\Model\Product\Attribute\Source\Status::STATUS_ENABLED,
-        );
-
-        $storeId = 0;
-
-        /** @var \Magento\Catalog\Model\ProductFactory $productFactory */
-        $productFactory = $this->_objectManager->get('\Magento\Catalog\Model\ProductFactory');
-        $productIds = $productFactory->create()->getCollection()->getAllIds();
-        /** @var \Magento\Catalog\Model\Product\Action $action */
-        $this->_objectManager->get('\Magento\Catalog\Model\Product\Action')->updateAttributes(
-            $productIds,
-            $attrData,
-            $storeId
-        );
-
     }
-
 }


### PR DESCRIPTION
We noticed that `Connector\Model\Feed\ProductFeed::INCLUDE_IN_FEED_FLAG` is the default value of the `ProductFeed::INCLUDE_IN_FEED_FLAG` attribute, so this PR suggests removing all of the code related to

```
$this->_objectManager->get('\Magento\Catalog\Model\Product\Action')->updateAttributes(
    $productIds,
    $attrData,
    $storeId
);
```

Which fixes https://github.com/bazaarvoice/magento2-extension/issues/7