### PR TITLE
Tweak getBvApiHostUrl() method with locale check

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -72,7 +72,10 @@ class Data extends AbstractHelper
         /** Note that this doesn't use Magento's locale, this will allow clients to override this and map it as they see fit */
         $localeCode = $this->getConfig('general/locale', $store);
         /** Build url string */
-        $url = '//' . $apiHostname . '/' . $static . $clientName . '/' . $deploymentZoneName . '/' . $localeCode;
+        $url = '//' . $apiHostname . '/' . $static . $clientName . '/' . $deploymentZoneName;
+        if (!empty($localeCode)) {
+            $url .= '/' . $localeCode;
+        }
         /** Return final url */
         return $url;
     }


### PR DESCRIPTION
In the case where `$localeCode` is an empty string, prevent the appending of an extra `/` in the url.