### PR TITLE
#13 Fixes inconsistency in generating legal product IDs between the M…

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -106,7 +106,7 @@ class Data extends AbstractHelper
             $rawProductId = $product;
 
         /** Customizations go here */
-        $rawProductId = preg_replace_callback('/\./s', create_function('$match', 'return "_bv".ord($match[0])."_";'), $rawProductId);
+
         /** No further customizations after this */
 
         return $this->replaceIllegalCharacters($rawProductId);
@@ -131,7 +131,7 @@ class Data extends AbstractHelper
          * Example encoded = qwerty_bv36__bv37__bv64__bv35_asdf
          */
 
-        return preg_replace_callback('/[^\w\d\*-\-_]/s', create_function('$match', 'return "_bv".ord($match[0])."_";'), $rawId);
+        return preg_replace_callback('/[^\w\d\*-\-\._]/s', create_function('$match', 'return "_bv".ord($match[0])."_";'), $rawId);
     }
 
 


### PR DESCRIPTION
…agento1 and Magento2 module. This ensures that data will continue to get pulled into Magento2 stores when the product ID has a perfectly legal period in it.

To the best of my sleuthing, the "customization" was probably an experiment was that accidentally committed when the module was ported to Magento2. I cannot think of any good reason why BV would want to cut their customers off of the data they have been generating, by introducing a new regular expression format and banning periods, which are part of Magento product IDs.