### PR TITLE
Fixed Issue - Integration test bootstrap process fails with Bazaarvoice installed

### DIFF
--- a/Console/Command/Export.php
+++ b/Console/Command/Export.php
@@ -17,12 +17,28 @@
 
 namespace Bazaarvoice\Connector\Console\Command;
 
+use Bazaarvoice\Connector\Model\Feed\Export as FeedExport;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputInterface;
 
 class Export extends Command
 {
+    /**
+     * @var FeedExport
+     */
+    protected $_exporter;
+
+    /**
+     * Export constructor.
+     *
+     * @param FeedExport $exporter
+     */
+    public function __construct(FeedExport $exporter)
+    {
+        $this->exporter = $exporter;
+    }
+
     protected function configure()
     {
         $this->setName('bv:export')->setDescription('Generates Bazaarvoice formatted Magento reviews.');
@@ -34,10 +50,8 @@ class Export extends Command
         // @codingStandardsIgnoreEnd
         echo "\n" . 'Memory usage: ' . memory_get_usage() . "\n";
 
-        /** @var \Bazaarvoice\Connector\Model\Feed\Export $exporter */
-        $exporter = \Magento\Framework\App\ObjectManager::getInstance()->get('Bazaarvoice\Connector\Model\Feed\Export');
         try {
-            $exporter->exportReviews();
+            $this->_exporter->exportReviews();
         } Catch (\Exception $e) {
             echo $e->getMessage() . "\n" . $e->getTraceAsString();
         }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -54,6 +54,27 @@
             </argument>
         </arguments>
     </type>
+    <!-- Configure the console command feed dependencies as proxies to prevent Feed::__construct() during setup -->
+    <type name="Bazaarvoice\Connector\Console\Command\Product">
+        <arguments>
+            <argument name="productFeed" xsi:type="object">Bazaarvoice\Connector\Model\Feed\ProductFeed\Proxy</argument>
+        </arguments>
+    </type>
+    <type name="Bazaarvoice\Connector\Console\Command\Export">
+        <arguments>
+            <argument name="exporter" xsi:type="object">Bazaarvoice\Connector\Model\Feed\Export\Proxy</argument>
+        </arguments>
+    </type>
+    <type name="Bazaarvoice\Connector\Console\Command\Purchase">
+        <arguments>
+            <argument name="purchaseFeed" xsi:type="object">Bazaarvoice\Connector\Model\Feed\PurchaseFeed\Proxy</argument>
+        </arguments>
+    </type>
+    <type name="Bazaarvoice\Connector\Console\Command\Index">
+        <arguments>
+            <argument name="indexer" xsi:type="object">Bazaarvoice\Connector\Model\Indexer\Flat\Proxy</argument>
+        </arguments>
+    </type>
 
     <!-- Logging -->
     <type name="Bazaarvoice\Connector\Logger\Handler">


### PR DESCRIPTION
Changed CLI command feed dependencies to proxy objects to prevent their constructors being called during the Magento setup process

This prevents the following exception from occuring during the bootstrap install process of Magento's integration tests with the Bazaarvoice extension installed:

```
SQLSTATE[42S02]: Base table or view not found: 1146 Table 'magento_integration_tests.flag' doesn't exist, query was: SELECT `flag`.* FROM `flag` WHERE (`flag`.`flag_code`='staging')
```

This bug affects Magento Commerce 2.2.1 and 2.2.2 (possibly others), as they have the Magento_Staging module.

Outside of affected versions (i.e. Magento Open Source), the constructors for each of the feed objects are heavy to initialise and require database connectivity (to access configuration values via the Bazaarvoice helper), so it's more performant in all cases to configure these dependencies as a proxy.

Fixes #20