### PR TITLE
KAT0001-840: update to fix getSku() null on catalog product view page…

### DIFF
--- a/Block/Product.php
+++ b/Block/Product.php
@@ -77,8 +77,10 @@ class Product extends \Magento\Framework\View\Element\Template
      */
     public function getProductId()
     {
-        $product = $this->_coreRegistry->registry('product');
-        return $product ? $product->getId() : null;
+        if ($this->getProduct()) {
+            return $this->getProduct()->getId();
+        }
+        return null;
     }
 
     public function getContainerUrl()
@@ -94,14 +96,16 @@ class Product extends \Magento\Framework\View\Element\Template
     }
 
     /**
+     * Get product object from core registry object
+     *
      * @return bool|\Magento\Catalog\Model\Product
      */
     public function getProduct()
     {
-        if (is_numeric($this->getProductId())) {
-            $product = $this->objectManager->get('Magento\Catalog\Model\Product')->load($this->getProductId());
-            return $product;
+        if ($this->_coreRegistry->registry('product')) {
+            return $this->_coreRegistry->registry('product');
         }
+
         return false;
     }
 
@@ -142,5 +146,17 @@ class Product extends \Magento\Framework\View\Element\Template
         return json_encode($children, JSON_UNESCAPED_UNICODE);
     }
 
+    /**
+     * Add checking product before render block HTML
+     *
+     * @return string
+     */
+    protected function _toHtml()
+    {
+        if ($this->getProduct()) {
+            return parent::_toHtml();
+        }
 
+        return '';
+    }
 }


### PR DESCRIPTION
Error on catalog product view page

> 2018/03/28 06:24:01 [error] 10#0: *29572 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Uncaught Error: Call to a member function getSku() on null in /var/www/current/src/vendor/bazaarvoice/bazaarvoice-magento2-ext/Block/Product.php:92
Stack trace:
#0 [internal function]: Bazaarvoice\Connector\Block\Product->getProductSku()
#1 /var/www/current/src/vendor/magento/framework/View/TemplateEngine/Php.php(82): call_user_func_array(Array, Array)
#2 /var/www/current/src/vendor/bazaarvoice/bazaarvoice-magento2-ext/view/frontend/templates/productheader.phtml(25): Magento\Framework\View\TemplateEngine\Php->__call('getProductSku', Array)
#3 /var/www/current/src/vendor/magento/framework/View/TemplateEngine/Php.php(59): include('/var/www/curren...')
#4 /var/www/current/src/vendor/magento/framework/View/Element/Template.php(270): Magento\Framework\View\TemplateEngine\Php->render(Object(Bazaarvoice\Connector\Block\Reviews), '/var/www/curren...', Array)
#5 /var/www/current/src/vendor/magento/framework/View/Element/Template.php(300):