### PR TITLE
update di.xml to fix search page error issue

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -6,9 +6,9 @@
     <type name="Magento\Catalog\Block\Product\ListProduct">
         <plugin name="bazaarvoice-category" type="Bazaarvoice\Connector\Block\ProductList\Category" sortOrder="100"/>
     </type>
-    <type name="Magento\CatalogSearch\Block\SearchResult\ListProduct">
+    <virtualType name="Magento\CatalogSearch\Block\SearchResult\ListProduct">
         <plugin name="bazaarvoice-search" type="Bazaarvoice\Connector\Block\ProductList\Search" sortOrder="100"/>
-    </type>
+    </virtualType>
     <type name="Magento\Catalog\Block\Product\ProductList\Upsell">
         <plugin name="bazaarvoice-upsell" type="Bazaarvoice\Connector\Block\ProductList\Upsell" sortOrder="100"/>
     </type>


### PR DESCRIPTION
Getting below error on search page on Magento 2.2.5

`Exception #0 (RuntimeException): Source class "\Magento\CatalogSearch\Block\SearchResult\ListProduct" for "Magento\CatalogSearch\Block\SearchResult\ListProduct\Interceptor" generation does not exist.`

it's being solved if I make changes on the di.xml file for `Magento\CatalogSearch\Block\SearchResult\ListProduct`

if I change it to virtualType in place of the type it's working fine and it's currently breaking our site, can you please release that fix?