### PR TITLE
README.md change: Link to Magento 2 resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is the official Magento 2 extension for Bazaarvoice.
 
 ## Getting Started
 
-Please visit our Bazaarvoice Knowledge website and start with our step by step integration guide for Magento 2: http://knowledge.bazaarvoice.com/partner-integrations/#magento2
+Please visit our Bazaarvoice Knowledge website and start with our step by step integration guide for Magento 2: https://knowledge.bazaarvoice.com/wp-content/partnerintegrations/en_US/ecommerce.html#magento-2
 
 ## Installation via Composer
 


### PR DESCRIPTION
Correction to link/location for Magento 2 resources on knowledge.bazaarvoice.com, supports change that we will publish on 12/14/2018