### PR TITLE
Dynamization of order status for purchase feed export

### DIFF
--- a/Model/Feed/PurchaseFeed.php
+++ b/Model/Feed/PurchaseFeed.php
@@ -58,6 +58,10 @@ class PurchaseFeed extends Feed
      * @var \Magento\Framework\App\ResourceConnection
      */
     private $resourceConnection;
+    /**
+     * @var array
+     */
+    private $orderStatus;
 
     /**
      * Constructor
@@ -85,7 +89,8 @@ class PurchaseFeed extends Feed
         State $state,
         Image $imageHelper,
         CollectionFactory $orderCollectionFactory,
-        ResourceConnection $resourceConnection
+        ResourceConnection $resourceConnection,
+        $orderStatus = []
     ) {
         try {
             $state->getAreaCode();
@@ -102,6 +107,7 @@ class PurchaseFeed extends Feed
         $this->imageHelper = $imageHelper;
         $this->orderCollectionFactory = $orderCollectionFactory;
         $this->resourceConnection = $resourceConnection;
+        $this->orderStatus = $orderStatus;
     }
 
     /**
@@ -407,10 +413,7 @@ class PurchaseFeed extends Feed
         /** Status is 'complete' or 'closed' */
         if ($this->test == false) {
             $orders->addFieldToFilter('status', [
-                'in' => [
-                    'complete',
-                    'closed',
-                ],
+                'in' => $this->orderStatus,
             ]);
         }
 

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -99,7 +99,17 @@
             <argument name="indexer" xsi:type="object">Bazaarvoice\Connector\Model\Indexer\Flat\Proxy</argument>
         </arguments>
     </type>
-
+    
+    <!-- Purchase Feed Status definition -->
+    <type name="Bazaarvoice\Connector\Model\Feed\PurchaseFeed">
+        <arguments>
+            <argument name="orderStatus" xsi:type="array">
+                <item name="complete" xsi:type="string">complete</item>
+                <item name="closed" xsi:type="string">closed</item>
+            </argument>
+        </arguments>
+    </type>
+    
     <!-- Logging -->
     <type name="Bazaarvoice\Connector\Logger\Handler">
         <arguments>


### PR DESCRIPTION
Currently exportable orders are filtered with hardcoded order status. Due to possible order status customizations it is useful to make exportable order status configurable via di.xml arguments.