### PR TITLE
BV Missing user_defined=0 attributes from the list

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,5 +13,8 @@
     "psr-4": {
       "Bazaarvoice\\Connector\\": ""
     }
+  },
+  "require": {
+    "php": "~7.0"
   }
 }


### PR DESCRIPTION
* updated product attribute source model implementation
* added PHP 7 requirement into composer.json

Multiple projects are using 3rd party modules which can introduce attributes with flag is_user_defined=0 to guarantee no one is able to change its configuration manually. Due to unnecessary condition in PriceAttribute source model such attributes are not available for selection.

The PR includes minor refactoring, overall module version was not increased as there might be internal policy around that.