### PR TITLE
BV Missing XMLWriter in Reviews Export Component

### DIFF
--- a/Model/Feed/Export.php
+++ b/Model/Feed/Export.php
@@ -12,6 +12,7 @@ use Bazaarvoice\Connector\Api\ConfigProviderInterface;
 use Bazaarvoice\Connector\Api\StringFormatterInterface;
 use Bazaarvoice\Connector\Logger\Logger;
 use Bazaarvoice\Connector\Model\XMLWriter;
+use Magento\Framework\Filesystem\Io\File;
 use Magento\Framework\UrlFactory;
 use Magento\Review\Model\Review;
 use Magento\Review\Model\ReviewFactory;
@@ -42,6 +43,7 @@ class Export extends Feed
      * @param StringFormatterInterface $stringFormatter
      * @param ConfigProviderInterface $configProvider
      * @param XMLWriter $XMLWriter
+     * @param File $filesystem
      */
     public function __construct(
         Logger $logger,
@@ -49,7 +51,8 @@ class Export extends Feed
         UrlFactory $urlFactory,
         StringFormatterInterface $stringFormatter,
         ConfigProviderInterface $configProvider,
-        XMLWriter $XMLWriter
+        XMLWriter $XMLWriter,
+        File $filesystem
     ) {
         $this->reviewFactory = $reviewFactory;
         $this->urlFactory = $urlFactory;
@@ -57,6 +60,7 @@ class Export extends Feed
         $this->configProvider = $configProvider;
         $this->logger = $logger;
         $this->xmlWriter = $XMLWriter;
+        $this->filesystem = $filesystem;
     }
 
     public function exportReviews()

--- a/Model/Feed/Export.php
+++ b/Model/Feed/Export.php
@@ -11,7 +11,7 @@ namespace Bazaarvoice\Connector\Model\Feed;
 use Bazaarvoice\Connector\Api\ConfigProviderInterface;
 use Bazaarvoice\Connector\Api\StringFormatterInterface;
 use Bazaarvoice\Connector\Logger\Logger;
-use Magento\Framework\ObjectManagerInterface;
+use Bazaarvoice\Connector\Model\XMLWriter;
 use Magento\Framework\UrlFactory;
 use Magento\Review\Model\Review;
 use Magento\Review\Model\ReviewFactory;
@@ -27,32 +27,36 @@ class Export extends Feed
      * @var \Magento\Review\Model\ReviewFactory
      */
     protected $reviewFactory;
+
     /**
      * @var \Magento\Framework\UrlFactory
      */
     protected $urlFactory;
 
     /**
-     * Category constructor.
+     * Export constructor.
      *
-     * @param Logger                   $logger
-     * @param ReviewFactory            $reviewFactory
-     * @param UrlFactory               $urlFactory
+     * @param Logger $logger
+     * @param ReviewFactory $reviewFactory
+     * @param UrlFactory $urlFactory
      * @param StringFormatterInterface $stringFormatter
-     * @param ConfigProviderInterface  $configProvider
+     * @param ConfigProviderInterface $configProvider
+     * @param XMLWriter $XMLWriter
      */
     public function __construct(
         Logger $logger,
         ReviewFactory $reviewFactory,
         UrlFactory $urlFactory,
         StringFormatterInterface $stringFormatter,
-        ConfigProviderInterface $configProvider
+        ConfigProviderInterface $configProvider,
+        XMLWriter $XMLWriter
     ) {
         $this->reviewFactory = $reviewFactory;
         $this->urlFactory = $urlFactory;
         $this->stringFormatter = $stringFormatter;
         $this->configProvider = $configProvider;
         $this->logger = $logger;
+        $this->xmlWriter = $XMLWriter;
     }
 
     public function exportReviews()

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "license": [
     "MIT"
   ],
-  "version": "8.1.11",
+  "version": "8.1.12",
   "autoload": {
     "files": [
       "registration.php"


### PR DESCRIPTION
* added explicit XMLWriter in construct as it is missing when implicitly used inside exportReviews method

The problem appears when bv:export CLI procedure is triggered invoking reviews component.

```
php bin/magento bv:export -vv

Memory usage: 105792464

Fatal error: Uncaught Error: Call to a member function openMemory() on null in versions/52892e0f5/vendor/bazaarvoice/bazaarvoice-magento2-ext/Model/Feed/Feed.php:239
Stack trace:
#0 versions/52892e0f5/vendor/bazaarvoice/bazaarvoice-magento2-ext/Model/Feed/Export.php(66): Bazaarvoice\Connector\Model\Feed\Feed->openFile('', 'CLIENT_NAME')
#1 versions/52892e0f5/generated/code/Bazaarvoice/Connector/Model/Feed/Export/Proxy.php(95): Bazaarvoice\Connector\Model\Feed\Export->exportReviews()
#2 versions/52892e0f5/vendor/bazaarvoice/bazaarvoice-magento2-ext/Console/Command/Export.php(55): Bazaarvoice\Connector\Model\Feed\Export\Proxy->exportReviews()
#3 versions/52892e0f5/vendor/symfony/console/Command/Command.php(255): Bazaarvoice\Connector\Console\Command\Export->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#4 /data/branches/test/ber in versions/52892e0f5/vendor/bazaarvoice/bazaarvoice-magento2-ext/Model/Feed/Feed.php on line 239
```