### PR TITLE
Fix for upgrading module from 8.x to master (related to issue #77)

### DIFF
--- a/Setup/Patch/Data/UpgradeBvDataAtttribute.php
+++ b/Setup/Patch/Data/UpgradeBvDataAtttribute.php
@@ -153,7 +153,7 @@ class UpgradeBvDataAtttribute implements DataPatchInterface, PatchRevertableInte
         $eavSetup = $this->categorySetupFactory->create(['setup' => $this->moduleDataSetup]);
         $entityTypeId = $eavSetup->getEntityTypeId(Product::ENTITY);
 
-        if ($eavSetup->getAttribute($entityTypeId, 'bv_feed_exclude')) {
+        if ($eavSetup->getAttribute($entityTypeId, 'bv_feed_exclude') && !$eavSetup->getAttribute($entityTypeId, 'bv_feed_include')) {
             $eavSetup->updateAttribute(
                 $entityTypeId,
                 'bv_feed_exclude',


### PR DESCRIPTION
Related to https://github.com/bazaarvoice/magento2-extension/issues/77 (but issue #77 is related to tag 9.0.0)

There's still an issue when ugrading the module from 8.x (8.3.5 in my case) to master branch.

### Pre-requisites

Bazaarvoice extension installed in version 8.3.5
Bazaarvoice extension updated to master branch

### Issue

A mysql error shows up when executing `bin/magento set:up` command:

```
Unable to apply data patch Bazaarvoice\Connector\Setup\Patch\Data\UpgradeBvDataAtttribute for module Bazaarvoice_Connector. Original exception message: SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '4-bv_feed_include' for key 'eav_attribute.EAV_ATTRIBUTE_ENTITY_TYPE_ID_ATTRIBUTE_CODE', query was: UPDATE `eav_attribute` SET `attribute_code` = ? WHERE (`attribute_id`='618')
```

### Solution

Check if the attribute code to be set (`bv_feed_include`) already exists in database.

Please see the code I have pushed to check the possible fix
