### PR TITLE
BV Logger crit method issue

### DIFF
--- a/Model/CurrentProductProvider.php
+++ b/Model/CurrentProductProvider.php
@@ -68,7 +68,7 @@ class CurrentProductProvider
                 }
                 $this->currentProduct = $this->productRepository->getById($product->getId());
             } catch (Exception $e) {
-                $this->bvLogger->crit($e->getMessage()."\n".$e->getTraceAsString());
+                $this->bvLogger->critical($e->getMessage()."\n".$e->getTraceAsString());
 
                 return false;
             }

--- a/Model/Feed/Feed.php
+++ b/Model/Feed/Feed.php
@@ -310,7 +310,7 @@ abstract class Feed
                 $ioObject->mv($sourceFile, $sentFile);
             }
         } catch (Exception $e) {
-            $this->logger->err($e->getMessage());
+            $this->logger->error($e->getMessage());
         }
     }
 }

--- a/Model/Feed/Feed.php
+++ b/Model/Feed/Feed.php
@@ -89,7 +89,7 @@ abstract class Feed
                 break;
             }
         } catch (Exception $e) {
-            $this->logger->crit($e->getMessage()."\n".$e->getTraceAsString());
+            $this->logger->critical($e->getMessage()."\n".$e->getTraceAsString());
         }
         $this->logger->debug('End Bazaarvoice '.$this->typeId.' Feed Generation');
     }
@@ -121,7 +121,7 @@ abstract class Feed
                     'Failed to export daily '.$this->typeId.' feed for store group: '
                     .$storeGroup->getName()
                 );
-                $this->logger->crit($e->getMessage()."\n".$e->getTraceAsString());
+                $this->logger->critical($e->getMessage()."\n".$e->getTraceAsString());
             }
         }
     }
@@ -143,7 +143,7 @@ abstract class Feed
                 }
             } catch (Exception $e) {
                 $this->logger->error('Failed to export daily '.$this->typeId.' feed for store: '.$store->getCode());
-                $this->logger->crit($e->getMessage()."\n".$e->getTraceAsString());
+                $this->logger->critical($e->getMessage()."\n".$e->getTraceAsString());
             }
         }
     }
@@ -164,7 +164,7 @@ abstract class Feed
                 }
             } catch (Exception $e) {
                 $this->logger->error('Failed to export daily '.$this->typeId.' feed for website: '.$website->getName());
-                $this->logger->crit($e->getMessage()."\n".$e->getTraceAsString());
+                $this->logger->critical($e->getMessage()."\n".$e->getTraceAsString());
             }
         }
     }
@@ -181,7 +181,7 @@ abstract class Feed
             }
         } catch (Exception $e) {
             $this->logger->error('Failed to export daily '.$this->typeId.' feed.');
-            $this->logger->crit($e->getMessage()."\n".$e->getTraceAsString());
+            $this->logger->critical($e->getMessage()."\n".$e->getTraceAsString());
         }
     }
 

--- a/Model/Filesystem/Io/Sftp.php
+++ b/Model/Filesystem/Io/Sftp.php
@@ -13,23 +13,4 @@ namespace Bazaarvoice\Connector\Model\Filesystem\Io;
  */
 class Sftp extends \Magento\Framework\Filesystem\Io\Sftp
 {
-    /**
-     * @var \phpseclib\Net\SFTP $_connection
-     */
-    protected $_connection = null;
-
-    /**
-     * Fixes Magento 2.1 phpseclib notice.
-     *
-     * @param $filename
-     * @param $source
-     * @param null $mode
-     *
-     * @return mixed
-     */
-    public function write($filename, $source, $mode = null)
-    {
-        $mode = is_readable($source) ? \phpseclib\Net\SFTP::SOURCE_LOCAL_FILE : \phpseclib\Net\SFTP::SOURCE_STRING;
-        return $this->_connection->put($filename, $source, $mode);
-    }
 }

--- a/Model/Indexer/Eav.php
+++ b/Model/Indexer/Eav.php
@@ -255,7 +255,7 @@ class Eav implements IndexerActionInterface, MviewActionInterface
                 $this->logStats();
             }
         } catch (Exception $e) {
-            $this->logger->crit($e->getMessage()."\n".$e->getTraceAsString());
+            $this->logger->critical($e->getMessage()."\n".$e->getTraceAsString());
         }
 
         return true;
@@ -718,7 +718,7 @@ class Eav implements IndexerActionInterface, MviewActionInterface
                         }
                     }
                 } catch (Exception $e) {
-                    $this->logger->crit($e->getMessage()."\n".$e->getTraceAsString());
+                    $this->logger->critical($e->getMessage()."\n".$e->getTraceAsString());
                 }
             }
         }
@@ -1091,10 +1091,10 @@ class Eav implements IndexerActionInterface, MviewActionInterface
                     $existingIndex->addData($bvIndex->getData());
                     $this->indexRepository->save($existingIndex);
                 } catch (Exception $e) {
-                    $this->logger->crit($e->getMessage()."\n".$e->getTraceAsString());
+                    $this->logger->critical($e->getMessage()."\n".$e->getTraceAsString());
                 }
             } catch (Exception $e) {
-                $this->logger->crit($e->getMessage()."\n".$e->getTraceAsString());
+                $this->logger->critical($e->getMessage()."\n".$e->getTraceAsString());
             }
         }
     }

--- a/Model/Indexer/Eav.php
+++ b/Model/Indexer/Eav.php
@@ -182,7 +182,7 @@ class Eav implements IndexerActionInterface, MviewActionInterface
             $this->logger->debug(__('Bazaarvoice Product Feed Index is being rebuilt via cron.'));
             $this->execute();
         } catch (Exception $e) {
-            $this->logger->err($e->getMessage()."\n".$e->getTraceAsString());
+            $this->logger->error($e->getMessage()."\n".$e->getTraceAsString());
         }
 
         return true;

--- a/Model/Indexer/Flat.php
+++ b/Model/Indexer/Flat.php
@@ -270,7 +270,7 @@ class Flat implements IndexerActionInterface, MviewActionInterface
                 $this->logStats();
             }
         } catch (Exception $e) {
-            $this->logger->crit($e->getMessage()."\n".$e->getTraceAsString());
+            $this->logger->critical($e->getMessage()."\n".$e->getTraceAsString());
         }
 
         return true;
@@ -574,7 +574,7 @@ class Flat implements IndexerActionInterface, MviewActionInterface
         try {
             $rows = $select->query();
         } catch (Exception $e) {
-            $this->logger->crit($e->getMessage()."\n".$e->getTraceAsString());
+            $this->logger->critical($e->getMessage()."\n".$e->getTraceAsString());
             if (strpos($e->getMessage(), 'Column not found') !== false) {
                 $errorExplanation = 'The following "Column not found" error typically results from a product attribute missing from the flat product table. Please ensure that the attribute referenced in the error is set to Use In Product Listing = Yes, which should cause a reindex to add it to the product flat table that is being queried: ' . $e->getMessage();
                 throw new Exception($errorExplanation, 0, $e);
@@ -795,7 +795,7 @@ class Flat implements IndexerActionInterface, MviewActionInterface
                         }
                     }
                 } catch (Exception $e) {
-                    $this->logger->crit($e->getMessage()."\n".$e->getTraceAsString());
+                    $this->logger->critical($e->getMessage()."\n".$e->getTraceAsString());
                 }
             }
         }
@@ -1142,10 +1142,10 @@ class Flat implements IndexerActionInterface, MviewActionInterface
                     $existingIndex->addData($bvIndex->getData());
                     $this->indexRepository->save($existingIndex);
                 } catch (Exception $e) {
-                    $this->logger->crit($e->getMessage()."\n".$e->getTraceAsString());
+                    $this->logger->critical($e->getMessage()."\n".$e->getTraceAsString());
                 }
             } catch (Exception $e) {
-                $this->logger->crit($e->getMessage()."\n".$e->getTraceAsString());
+                $this->logger->critical($e->getMessage()."\n".$e->getTraceAsString());
             }
         }
     }

--- a/Model/Indexer/Flat.php
+++ b/Model/Indexer/Flat.php
@@ -196,7 +196,7 @@ class Flat implements IndexerActionInterface, MviewActionInterface
             $this->logger->debug(__('Bazaarvoice Product Feed Index is being rebuilt.'));
             $this->execute();
         } catch (Exception $e) {
-            $this->logger->err($e->getMessage()."\n".$e->getTraceAsString());
+            $this->logger->error($e->getMessage()."\n".$e->getTraceAsString());
         }
 
         return true;

--- a/ViewModel/Product.php
+++ b/ViewModel/Product.php
@@ -196,7 +196,7 @@ class Product implements ArgumentInterface
                 return $this->getProduct()->getTypeId() == Configurable::TYPE_CODE;
             }
         } catch (Exception $e) {
-            $this->bvLogger->crit($e->getMessage()."\n".$e->getTraceAsString());
+            $this->bvLogger->critical($e->getMessage()."\n".$e->getTraceAsString());
         }
 
         return false;

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "license": [
     "MIT"
   ],
-  "version": "9.1.5",
+  "version": "9.1.6",
   "autoload": {
     "files": [
       "registration.php"
@@ -15,6 +15,8 @@
     }
   },
   "require": {
-    "php": "~7.0||~8.1.0" ,"magento/framework": "~100.1|~101.0|~102.0|~103.0|~104.0"  
+    "php": "~7.0||~8.1.0" ,
+    "magento/framework": "~100.1|~101.0|~102.0|~103.0|~104.0",
+    "monolog/monolog": "*"
   }
 }


### PR DESCRIPTION
* Monolor Logger method use refactoring

Bazaavoice "Logger" through the extension of `Monolog/Logger` class does not have `crit` method which is in use across some classes of the module. Must be replaced with `critical`

The error message generated
```
report.CRITICAL: Error: Call to undefined method Bazaarvoice\Connector\Logger\Logger\Interceptor::crit() in 
/[SOME_PATH]/vendor/bazaarvoice/bazaarvoice-magento2-ext/Model/Indexer/Flat.php:577 Stack trace: 
#0 /[SOME_PATH]/vendor/bazaarvoice/bazaarvoice-magento2-ext/Model/Indexer/Flat.php(412): 
Bazaarvoice\Connector\Model\Indexer\Flat->populateIndexStoreData(Array, Object(Magento\Store\Model\Store\Interceptor)) 
```